### PR TITLE
Fix/registered later providers

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -22,7 +22,7 @@ jobs:
                 run: composer install -q -n -a --no-progress --prefer-dist
 
             -   name: Run unit tests
-                run: ./vendor/bin/phpunit --testsuite=unit --no-coverage
+                run: ./vendor/bin/phpunit --testsuite=all --no-coverage
 
             -   name: Check code styles
                 run: ./vendor/bin/phpcs

--- a/src/Container.php
+++ b/src/Container.php
@@ -20,7 +20,7 @@ final class Container implements ContainerInterface
     private $config;
 
     /**
-     * @var Context
+     * @var ContextInterface
      */
     private $context;
 
@@ -36,12 +36,12 @@ final class Container implements ContainerInterface
 
     /**
      * @param SiteConfig|null $config
-     * @param Context|null $context
+     * @param ContextInterface|null $context
      * @param ContainerInterface ...$containers
      */
     public function __construct(
         SiteConfig $config = null,
-        Context $context = null,
+        ContextInterface $context = null,
         ContainerInterface ...$containers
     ) {
 
@@ -73,9 +73,9 @@ final class Container implements ContainerInterface
     }
 
     /**
-     * @return Context
+     * @return ContextInterface
      */
-    public function context(): Context
+    public function context(): ContextInterface
     {
         return $this->context;
     }

--- a/src/Context.php
+++ b/src/Context.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Inpsyde\App;
 
-final class Context implements \JsonSerializable
+final class Context implements ContextInterface
 {
     public const AJAX = 'ajax';
     public const BACKOFFICE = 'backoffice';

--- a/src/ContextInterface.php
+++ b/src/ContextInterface.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Inpsyde\App;
+
+interface ContextInterface extends \JsonSerializable
+{
+    /**
+     * @param string $context
+     * @param string ...$contexts
+     * @return bool
+     */
+    public function is(string $context, string ...$contexts): bool;
+
+    /**
+     * @return bool
+     */
+    public function isCore(): bool;
+
+    /**
+     * @return bool
+     */
+    public function isFrontoffice(): bool;
+
+    /**
+     * @return bool
+     */
+    public function isBackoffice(): bool;
+
+    /**
+     * @return bool
+     */
+    public function isAjax(): bool;
+
+    /**
+     * @return bool
+     */
+    public function isLogin(): bool;
+
+    /**
+     * @return bool
+     */
+    public function isRest(): bool;
+
+    /**
+     * @return bool
+     */
+    public function isCron(): bool;
+
+    /**
+     * @return bool
+     */
+    public function isWpCli(): bool;
+
+    /**
+     * @return bool
+     */
+    public function isXmlRpc(): bool;
+
+    /**
+     * @return bool
+     */
+    public function isInstalling(): bool;
+}

--- a/src/ProviderStatus.php
+++ b/src/ProviderStatus.php
@@ -105,7 +105,8 @@ final class ProviderStatus implements \JsonSerializable
      */
     public function nowBooted(AppStatus $appStatus): ProviderStatus
     {
-        if ($this->status !== self::REGISTERED && $this->status !== self::ADDED) {
+        $allowedFromStatuses = [self::REGISTERED, self::REGISTERED_DELAYED, self::ADDED];
+        if (!in_array($this->status, $allowedFromStatuses, true)) {
             $this->cantMoveTo(self::BOOTED);
         }
 

--- a/tests/phpunit/Provider/ServiceProvidersTest.php
+++ b/tests/phpunit/Provider/ServiceProvidersTest.php
@@ -6,7 +6,9 @@ namespace Inpsyde\App\Tests\Provider;
 
 use Brain\Monkey\Actions;
 use Inpsyde\App\App;
+use Inpsyde\App\Container;
 use Inpsyde\App\Context;
+use Inpsyde\App\ContextInterface;
 use Inpsyde\App\Provider\ConfigurableProvider;
 use Inpsyde\App\Provider\ServiceProvider;
 use Inpsyde\App\Provider\ServiceProviders;
@@ -24,7 +26,13 @@ class ServiceProvidersTest extends TestCase
      */
     public function testProvideApp()
     {
-        $app = App::new();
+        $contextMock = $this->createMock(ContextInterface::class);
+        $contextMock
+            ->method('is')
+            ->with(Context::CORE)
+            ->willReturn(true);
+
+        $app = App::new(new Container(null, $contextMock));
 
         Actions\expectDone(App::ACTION_REGISTERED_PROVIDER)
             ->once()


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added
- [ ] Docs have been added / updated (not needed)


* **What kind of change does this PR introduce?** 
Bugfix.


* **What is the current behavior?** 
When debug enabled providers registered latter cannot boot. Instead, we get `DomainException: Can't move from status 'Registered with delay' to 'Booted'.` 


* **What is the new behavior ?**
Allow boot provider with `Registered with delay` status.


* **Does this PR introduce a breaking change?**
No


* **Other information**:
Unit tests were broken because `Context::create` generates empty context by default.  `ContextInterface` was extracted from `Context` class for properly mocking.