### PR TITLE
allow to boot registered later providers

### DIFF
--- a/src/ProviderStatus.php
+++ b/src/ProviderStatus.php
@@ -105,7 +105,8 @@ final class ProviderStatus implements \JsonSerializable
      */
     public function nowBooted(AppStatus $appStatus): ProviderStatus
     {
-        if ($this->status !== self::REGISTERED && $this->status !== self::ADDED) {
+        $allowedFromStatuses = [self::REGISTERED, self::REGISTERED_DELAYED, self::ADDED];
+        if (!in_array($this->status, $allowedFromStatuses, true)) {
             $this->cantMoveTo(self::BOOTED);
         }
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated (not needed)


* **What kind of change does this PR introduce?** 
Bugfix.


* **What is the current behavior?** 
When debug enabled providers registered latter cannot boot. Instead, we get `DomainException: Can't move from status 'Registered with delay' to 'Booted'.` 


* **What is the new behavior ?**
Allow boot provider with `Registered with delay` status.


* **Does this PR introduce a breaking change?**
No