### PR TITLE
Improve ID generation

### DIFF
--- a/src/Provider/AutoDiscoverIdTrait.php
+++ b/src/Provider/AutoDiscoverIdTrait.php
@@ -7,12 +7,22 @@ namespace Inpsyde\App\Provider;
 trait AutoDiscoverIdTrait
 {
     /**
+     * @var string|null
+     */
+    private $discoveredId = null;
+
+    /**
      * @return string
      */
     public function id(): string
     {
+        if (is_string($this->discoveredId)) {
+            return $this->discoveredId;
+        }
+
         if (isset($this->id) && is_string($this->id)) {
-            return $this->id;
+            $this->discoveredId = $this->id;
+            return $this->discoveredId;
         }
 
         $class = get_called_class();
@@ -20,33 +30,16 @@ trait AutoDiscoverIdTrait
         if (defined("{$class}::ID")) {
             $byConstant = constant("{$class}::ID");
             if (is_string($byConstant)) {
-                return $byConstant;
+                $this->discoveredId = $byConstant;
+                return $this->discoveredId;
             }
         }
 
-        /** @var array<string, int> $classes */
-        static $classes = [];
+        /** @var int $instance */
+        static $instance = 0;
+        $instance++;
+        $this->discoveredId = "{$class}_{$instance}";
 
-        /** @var array<string, string> $hashes */
-        static $hashes = [];
-
-        isset($classes[$class]) or $classes[$class] = 0;
-
-        $hash = spl_object_hash($this);
-
-        if (isset($hashes[$hash])) {
-            return $hashes[$hash];
-        }
-
-        $classes[$class]++;
-
-        $id = $class;
-        if ($classes[$class] > 1) {
-            $id .= "_{$classes[$class]}";
-        }
-
-        $hashes[$hash] = $id;
-
-        return $id;
+        return $this->discoveredId;
     }
 }

--- a/tests/phpunit/Provider/AutoDiscoverIdTest.php
+++ b/tests/phpunit/Provider/AutoDiscoverIdTest.php
@@ -6,8 +6,11 @@ namespace Inpsyde\App\Tests\Provider;
 
 use Inpsyde\App\Container;
 use Inpsyde\App\Provider\RegisteredOnly;
-use Inpsyde\App\Tests\TestCase;
+use PHPUnit\Framework\TestCase;
 
+/**
+ * @runTestsInSeparateProcesses
+ */
 class AutoDiscoverIdTest extends TestCase
 {
     /**
@@ -54,7 +57,7 @@ class AutoDiscoverIdTest extends TestCase
             }
         };
 
-        static::assertSame(get_class($provider), $provider->id());
+        static::assertSame(get_class($provider) . '_1', $provider->id());
     }
 
     /**
@@ -76,9 +79,9 @@ class AutoDiscoverIdTest extends TestCase
         $two =  $provider2->id();
         $three =  $provider3->id();
 
-        static::assertSame($one, get_class($provider1));
-        static::assertSame("{$one}_2", $two);
-        static::assertStringEndsWith("{$one}_3", $three);
+        static::assertSame(get_class($provider1) . '_1', $one);
+        static::assertSame(get_class($provider2) . '_2', $two);
+        static::assertStringEndsWith(get_class($provider3) . '_3', $three);
 
         static::assertSame($one, $provider1->id());
         static::assertSame($one, $provider1->id());
@@ -86,5 +89,23 @@ class AutoDiscoverIdTest extends TestCase
         static::assertSame($two, $provider2->id());
         static::assertSame($three, $provider3->id());
         static::assertSame($three, $provider3->id());
+    }
+
+    public function testIfObjectHasNotReference(): void
+    {
+        $providerId1 = (new class extends RegisteredOnly {
+            public function register(Container $container): bool
+            {
+                return true;
+            }
+        })->id();
+        $providerId2 = (new class extends RegisteredOnly {
+            public function register(Container $container): bool
+            {
+                return true;
+            }
+        })->id();
+
+        static::assertNotSame($providerId1, $providerId2);
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix.


**What is the current behavior?** (You can also link to an open issue here)
The following snippet trigger Exception in debug mode: `PHP Fatal error:  Uncaught DomainException: Can't move from status 'Skipped' to 'Skipped'.` for frontend request on PHP 8.1.

```php
add_action(
            App::ACTION_ADD_PROVIDERS,
            static function (App $app) {
                $app->addProvider(
                    new DescriptionSettingsProvider(__DIR__),
                    WpContext::BACKOFFICE
                );
                $app->addProvider(
                    new AssetsProvider(__FILE__),
                    WpContext::BACKOFFICE
                );
            }
        );
```

It causes by PHP 8.1 changes on static variables within inherited methods https://www.php.net/manual/en/language.variables.scope.php#example-99. The next important note is the `spl_object_hash` function perfectly returns the same value if the object is not stored (so was destroyed by the garbage collector). So in the end `AutoDiscoverIdTrait::id()` for the second provider returns `DescriptionSettingsProvider` FQCN.

**What is the new behavior (if this is a feature change)?**

The purpose of the PR is to simplify id generation. Basically, we just need a unique ID (maybe we can even just use `uniqid` :thinking:). Tests are passed for PHP 7.* and PHP 8.1 as well.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No, hopefully.


**Other information**:
