### PR TITLE
PHP 8.1 Compatibility for the 2.x Version Branch

### DIFF
--- a/src/EnvConfig.php
+++ b/src/EnvConfig.php
@@ -255,7 +255,8 @@ class EnvConfig implements SiteConfig
     /**
      * @return array{env:string, hosting:string, keys:array<string>}
      */
-    public function jsonSerialize()
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize(): array
     {
         return [
             'env' => $this->env(),

--- a/src/ProviderStatus.php
+++ b/src/ProviderStatus.php
@@ -142,7 +142,8 @@ final class ProviderStatus implements \JsonSerializable
     /**
      * @return array<string, string>
      */
-    public function jsonSerialize()
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize(): array
     {
         return $this->appStatuses;
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR fixes two instances where the `jsonSerialize` method is not compatible with the definition of `JsonSerializable::jsonSerialize()`, which will result in a Deprecated notice on PHP 8.1.

**What is the current behavior?** (You can also link to an open issue here)

On PHP 8.1, you will see deprecation notices for the two instances, also triggering to "headers already sent" notices.

**What is the new behavior (if this is a feature change)?**

No notices.

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.

**Other information**:
