### PR TITLE
Docs: Update PHP_CodeSniffer repository link

### DIFF
--- a/README.md
+++ b/README.md
@@ -841,6 +841,6 @@ Before sending a PR make sure that `composer run qa` will output no errors.
 
 It will run, in turn:
 
-- [PHPCS](https://github.com/squizlabs/PHP_CodeSniffer) checks
+- [PHPCS](https://github.com/PHPCSStandards/PHP_CodeSniffer) checks
 - [Psalm](https://psalm.dev/) checks
 - [PHPUnit](https://phpunit.de/) tests


### PR DESCRIPTION
PHP_CodeSniffer has moved to a new GitHub organization. The `squizlabs/PHP_CodeSniffer` repository is now archived and the project is actively maintained at https://github.com/PHPCSStandards/PHP_CodeSniffer.

See: https://github.com/squizlabs/PHP_CodeSniffer/issues/3932