### PR TITLE
Fix PHP 8.4 deprecations

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -98,7 +98,7 @@ final class App
     {
         do_action(self::ACTION_ERROR, $throwable);
 
-        /** @psalm-suppress TypeDoesNotContainType */
+        /** @psalm-suppress RedundantCondition */
         if (defined('WP_DEBUG') && WP_DEBUG) {
             throw $throwable;
         }

--- a/src/App.php
+++ b/src/App.php
@@ -63,7 +63,7 @@ final class App
      * @param Container|null $container
      * @return App
      */
-    public static function new(Container $container = null): App
+    public static function new(?Container $container = null): App
     {
         $app = new App($container);
         self::$app or self::$app = $app;
@@ -107,7 +107,7 @@ final class App
     /**
      * @param Container|null $container
      */
-    private function __construct(Container $container = null)
+    private function __construct(?Container $container = null)
     {
         $this->status = AppStatus::new();
         $this->logger = AppLogger::new();

--- a/src/AppLogger.php
+++ b/src/AppLogger.php
@@ -28,7 +28,7 @@ final class AppLogger
 
     private function __construct()
     {
-        /** @psalm-suppress TypeDoesNotContainType */
+        /** @psalm-suppress RedundantCondition */
         $this->debugEnabled = defined('WP_DEBUG') && WP_DEBUG;
     }
 

--- a/src/Container.php
+++ b/src/Container.php
@@ -41,8 +41,8 @@ final class Container implements ContainerInterface
      * @param ContainerInterface ...$containers
      */
     public function __construct(
-        SiteConfig $config = null,
-        WpContext $context = null,
+        ?SiteConfig $config = null,
+        ?WpContext $context = null,
         ContainerInterface ...$containers
     ) {
 

--- a/src/EnvConfig.php
+++ b/src/EnvConfig.php
@@ -186,7 +186,7 @@ class EnvConfig implements SiteConfig
             return $this->env;
         }
 
-        /** @psalm-suppress TypeDoesNotContainType */
+        /** @psalm-suppress RedundantCondition */
         $env = (defined('WP_DEBUG') && WP_DEBUG) ? self::DEVELOPMENT : self::PRODUCTION;
         $this->env = $this->normalizeEnv($env, true);
 

--- a/src/Provider/ConfigurableProvider.php
+++ b/src/Provider/ConfigurableProvider.php
@@ -40,8 +40,8 @@ class ConfigurableProvider implements ServiceProvider
      */
     public function __construct(
         string $id,
-        callable $register = null,
-        callable $boot = null,
+        ?callable $register = null,
+        ?callable $boot = null,
         int $flags = 0
     ) {
 

--- a/tests/phpunit/AppTest.php
+++ b/tests/phpunit/AppTest.php
@@ -421,7 +421,7 @@ class AppTest extends TestCase
      * @param callable|null $register
      * @return ServiceProvider
      */
-    private static function factoryProvider(string $id, callable $register = null): ServiceProvider
+    private static function factoryProvider(string $id, ?callable $register = null): ServiceProvider
     {
         return new ConfigurableProvider($id, $register ?? '__return_true', '__return_true');
     }


### PR DESCRIPTION
## Please check if the PR fulfills these requirements
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)


## What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

PHP 8.4 deprecates **implicitly nullable types**. PHP applications are recommended to explicitly declare the type as `nullable`. All type declarations that have a default value of `null`, but without declaring `null` in the type declaration, emit a deprecation notice.

## What is the current behavior? (You can also link to an open issue here)

It produces a deprecation notice.

## What is the new behavior (if this is a feature change)?

The deprecation notice should be gone.

## Other information
https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated